### PR TITLE
add NNG and NNC as optional ambiguous codons

### DIFF
--- a/create_primers.py
+++ b/create_primers.py
@@ -17,7 +17,12 @@ For command line arguments, run::
 
 The  Tm_NN command of the MeltingTemp Module of Biopython (http://biopython.org/DIST/docs/api/Bio.SeqUtils.MeltingTemp-module.html) is used to calculate Tm of primers. 
 This calculation is based on nearest neighbor thermodynamics. nucelotides labeled N are given average values in the Tm calculation. 
-It is possible to vary salt concentration and other addatives if needed."""
+It is possible to vary salt concentration and other addatives if needed.
+
+Edited by Kate Crawford January 2021 to include options for `NNG` and `NNC`
+ambiguous codons to simulate `NNS` mutagenesis as IDT oPools only allow for
+`N` or `K` ambiguous nucelotides.
+"""
 
 
 import os
@@ -45,7 +50,7 @@ def Parser():
     parser.add_argument('--minprimertm', type=float, help="Lower temperature limit for primers.", default=60)
     parser.add_argument('--minlength', type=int, help='Minimum primer length', default=25)
     parser.add_argument('--maxlength', type=int, help='Maximum primer length', default=51)
-    parser.add_argument('--ambiguous_codon', choices={'NNN', 'NNS', 'NNK'},
+    parser.add_argument('--ambiguous_codon', choices={'NNN', 'NNS', 'NNK', 'NNC', 'NNG'},
                         default='NNN', help='What ambiguous codon to use')
     return parser
 

--- a/create_primers.py
+++ b/create_primers.py
@@ -109,7 +109,7 @@ def CreateMutForOligosVarLength(seq, primerlength, prefix, firstcodon, maxprimer
     for icodon in range(ncodons):
         i = startupper + icodon * 3
         primer = "%s%s%s" % (seq[i - initial_flanklength : i], ambiguous_codon, seq[i + 3 : i + 3 + initial_flanklength]) 
-        name = "%s-for-%s-mut%d" % (prefix, ambiguous_codon, firstcodon + icodon)
+        name = "%s-for-mut%d" % (prefix, firstcodon + icodon)
         primerseq = Seq(primer)
         
         TmNN = ('%0.2f' % mt.Tm_NN(primerseq, strict=False)) 
@@ -223,14 +223,14 @@ def main():
                 iplate += 1
     elif args['output'] == 'opools':
         f = open(outfile, 'w')
-        f.write("Pool name,Primer name,Sequence\r\n")
+        f.write("Pool name,Primer name,Ambiguous codon,Sequence\r\n")
         for primers in [mutforprimers, mutrevprimers]:
             if primers == mutforprimers:
                 pool = f"{primerprefix}_ForPool"
             elif primers == mutrevprimers:
                 pool = f"{primerprefix}_RevPool"
             for (name, primer) in primers:
-                f.write("%s,%s,%s\r\n" % (pool, name, primer))
+                f.write("%s,%s,%s,%s\r\n" % (pool, name, args['ambiguous_codon'], primer))
     else:
         raise ValueError(f"Invalid output of {args['output']}")
 


### PR DESCRIPTION
@jbloom As far as I could tell, the only thing preventing designing `NNG` or `NNC` codons was that they weren't options for "--ambiguous_codon". I added them and a brief look at the Env sequences seemed to work. I did not run any rigorous tests. Let me know if there's something you'd like me to do besides spot-checking.
